### PR TITLE
Fix btCurrency error in x64

### DIFF
--- a/Source/x64.inc
+++ b/Source/x64.inc
@@ -2380,7 +2380,7 @@ begin // function TPSExec.InnerfuseCall
         bts64:
           tbts64(res.dta^) := Int64(_RAX);
         btCurrency:
-          tbtCurrency(res.Dta^) := Int64(_RAX);
+          tbts64(res.Dta^) := Int64(_RAX);
 
         btInterface,
         btVariant,


### PR DESCRIPTION
Executing a script function returning `currency` data type in Win64 platform like:

    StrToCurr(''12.34'')

return wrong result: `123400` instead of `12.34`.

This is the test case to replay the issue:

```delphi
program sample5;

{$APPTYPE CONSOLE}

uses
  Winapi.Windows,
  System.SysUtils,
  uPSCompiler,
  uPSRuntime,
  uPSC_Classes,
  uPSC_std,
  uPSR_Classes,
  uPSR_std;

procedure GetValue(s: currency);
begin
  Writeln(s);
end;

function ScriptOnUses(Sender: TPSPascalCompiler; const Name: AnsiString): Boolean;
begin
  if Name = 'SYSTEM' then
  begin
    SIRegister_Std(Sender);
    SIRegister_Classes(Sender, False);
    Sender.AddDelphiFunction('function StrToCurr(const S: string): Currency');
    Sender.AddDelphiFunction('procedure GetValue(s: currency);');
    Result := True;
  end else
    Result := False;
end;

procedure ExecuteScript(const Script: string);
var
  Compiler: TPSPascalCompiler;
  Exec: TPSExec;
  Data: AnsiString;
  CI: TPSRuntimeClassImporter;
begin
  Compiler := TPSPascalCompiler.Create; // create an instance of the compiler.
  Compiler.OnUses := ScriptOnUses; // assign the OnUses event.
  if not Compiler.Compile(Script) then  // Compile the Pascal script into bytecode.
  begin
    Compiler.Free;
    Exit;
  end;

  Compiler.GetOutput(Data); // Save the output of the compiler in the string Data.
  Compiler.Free; // After compiling the script, there is no need for the compiler anymore.

  CI := TPSRuntimeClassImporter.Create;
  { Create an instance of the runtime class importer.}

  RIRegister_Std(CI);  // uPSR_std.pas unit.
  RIRegister_Classes(CI, True);

  Exec := TPSExec.Create;  // Create an instance of the executer.
  RegisterClassLibraryRuntime(Exec, CI);

  Exec.RegisterDelphiFunction(@StrToCurr, 'StrToCurr', cdRegister);
  Exec.RegisterDelphiFunction(@GetValue, 'GetValue', cdRegister);

  // Assign the runtime class importer to the executer.
  if not  Exec.LoadData(Data) then // Load the data from the Data string.
  begin
    Exec.Free;
    Exit;
  end;

  if not Exec.RunScript then // Run the script.
    WriteLn('Error');
  Exec.Free; // Free the executer.
  CI.Free;  // Free the runtime class importer.
end;

begin
  ExecuteScript('var a: currency; begin a := StrToCurr(''12.34''); GetValue(a); end.');
  Readln;
end.
```